### PR TITLE
Fix tar error in download script on Mac

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -15,7 +15,15 @@ download () {
   fi
 
   if [ ! -d "$DATA_DIR$UNZ_FILE_NAME" ]; then
-    tar --warning=no-unknown-keywor -zxf "$DATA_DIR$FILE_NAME.tar.gz" -C $DATA_DIR
+    # check if using GNU or BSD version of Tar. Only GNU Tar has option --warning=no-unknown-keywords
+    isGnuTar=$(tar --version | grep -q 'gnu')
+    if [ $? -eq 0 ]
+    then
+        # "Detected GNU tar"
+        tar --warning=no-unknown-keywords -zxf "$DATA_DIR$FILE_NAME.tar.gz" -C $DATA_DIR
+    else
+        tar -zxf "$DATA_DIR$FILE_NAME.tar.gz" -C $DATA_DIR
+    fi
   else
     echo "You've already unzipped $FILE_NAME dataset"
   fi

--- a/download.sh
+++ b/download.sh
@@ -20,7 +20,7 @@ download () {
     if [ $? -eq 0 ]
     then
         # "Detected GNU tar"
-        tar --warning=no-unknown-keywords -zxf "$DATA_DIR$FILE_NAME.tar.gz" -C $DATA_DIR
+        tar --warning=no-unknown-keyword -zxf "$DATA_DIR$FILE_NAME.tar.gz" -C $DATA_DIR
     else
         tar -zxf "$DATA_DIR$FILE_NAME.tar.gz" -C $DATA_DIR
     fi


### PR DESCRIPTION
On Mac (and any system using BSD Tar instead of GNU Tar, running `./download.sh` errored before extracting with:
```sh
tar: Option --warning=no-unknown-keyword is not supported
Usage:
  List:    tar -tf <archive-filename>
  Extract: tar -xf <archive-filename>
  Create:  tar -cf <archive-filename> [filenames...]
  Help:    tar --help
```
This PR fixes that by checking to see if `tar -v` contains the phrase `gnu`, and only if it does including `--warning=no-unknown-keyword`.

Also, there was a typo, it originally said `--warning=no-unknown-keywor`
